### PR TITLE
Fix typos in mfc-initial-version patchset

### DIFF
--- a/patches/mfc-initial-version/0012-mfc-Call-CWinApp-InitInstamce-in-AfxWinMain.patch
+++ b/patches/mfc-initial-version/0012-mfc-Call-CWinApp-InitInstamce-in-AfxWinMain.patch
@@ -135,7 +135,7 @@ index ca02e93ffc8..411083d17c4 100644
 +    return 0;
 +}
 +
-+DEFINE_THISCALL_WRAPPER(cwinappex_dtor, 4)
++DEFINE_THISCALL_WRAPPER(cwinappex_unk, 4)
 +void __thiscall cwinappex_unk(struct c_winappex *winapp)
 +{
 +    FIXME("%p\n", winapp);

--- a/patches/mfc-initial-version/0018-mfc-CWinApp-LoadStdProfileSettings-stub.patch
+++ b/patches/mfc-initial-version/0018-mfc-CWinApp-LoadStdProfileSettings-stub.patch
@@ -33,7 +33,7 @@ index c51f6c45e23..33065e78a8c 100644
 + * ?LoadStdProfileSettings@CWinApp@@IAEXI@Z
 + * ?LoadStdProfileSettings@CWinApp@@IEAAXI@Z
 + */
-+DEFINE_THISCALL_WRAPPER(cwinapp_SetRegistryKeyUINT, 8)
++DEFINE_THISCALL_WRAPPER(cwinapp_LoadStdProfileSettings, 8)
 +void __thiscall cwinapp_LoadStdProfileSettings(struct c_winappex *winapp, UINT maxnt)
 +{
 +    FIXME("%p, %u\n", winapp, maxnt);


### PR DESCRIPTION
I found these typos while trying the `mfc-initial-version` patchset with [wine-tkg](https://github.com/Frogging-Family/wine-tkg-git).